### PR TITLE
Updates to testing/lua-threads

### DIFF
--- a/lib/retrievestats.sh
+++ b/lib/retrievestats.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Copy interesting sqm-autorate files from OpenWrt to ~/Desktop
+# 
+# Run the getstats.sh script to create /tmp/openwrtscripts.txt
+# Compress it and the three /tmp/sqm-* files then copy (over SSH)
+# to a result file with a timestamp in the name
+# 
+# Usage:
+#    sh retrievestats.sh root@192.168.1.1 # login on OpenWrt
+# 
+# or just copy/paste the lines below into the command line, substituting root@ip-address for "$1"
+#    
+# Output is a file on ~/Desktop named
+#    openwrtstats-yyyy-mm-dd-hhmmss.gz
+
+ssh "$1" \
+"/usr/lib/sqm-autorate/getstats.sh > /dev/null; \
+cd /tmp; \
+tar -cvzf - \
+	openwrtstats.txt \
+	sqm-autorate.csv \
+	sqm-autorate.log \
+	sqm-speedhist.csv" \
+> ~/Desktop/openwrtstats-$(date "+%F-%H%M%S").gz
+
+# Notes:
+# - The script tar's and compresses on the fly so it doesn't
+#     consume (much) file system space on the OpenWrt target.
+# - The ssh command executes the getstats.sh script to get the
+#     current state of the router. Note that this will overwrite
+#     previously-saved copies of /tmp/openwrtstats.txt
+# - The `> /dev/null` prevents the getstats.sh script's output
+#     from polluting the resulting .gz file

--- a/sqm-autorate-setup.sh
+++ b/sqm-autorate-setup.sh
@@ -35,11 +35,12 @@ refl_icmp_file="reflectors-icmp.csv"
 refl_udp_file="reflectors-udp.csv"
 autorate_lib_path="/usr/lib/sqm-autorate"
 
-if [ -z "$1" ]; then
+# Set the repo_root URL that's the base for all files to be retrieved
+if [ -z "$1" ]; then # $1 is empty (no parameter at all)
     repo_root="https://raw.githubusercontent.com/sqm-autorate/sqm-autorate/testing/lua-threads"
-elif [ -z "$2" ]; then
+elif [ -z "$2" ]; then # $2 is empty (only one parameter)
     repo_root="https://raw.githubusercontent.com/sqm-autorate/sqm-autorate/${1}"
-else
+else # $1 & $2 are strings - build the root URL from scratch
     repo_root="https://raw.githubusercontent.com/${1}/sqm-autorate/${2}"
 fi
 
@@ -60,19 +61,50 @@ check_for_sqm() {
             fi
         else
             # We have to bail out if we don't have luci-app-sqm on OpenWrt...
-            echo "> You must install SQM (luci-app-sqm) before using sqm-autorate. Cannot continue. Exiting."
+            echo "> You must install SQM (luci-app-sqm) before using sqm-autorate. Aborting"
             exit 1
         fi
     else
-        echo "> Congratulations! You already have SQM (luci-app-sqm) installed. We can proceed with the sqm-autorate setup now..."
+        echo "> SQM (luci-app-sqm) already installed. Proceeding..."
     fi
 }
 
+#
+# Main Routine of setup.sh starts here
+# 
+
+# Check for the presence of the OpenWrt os_release file and the proper contents
+[ -f "$owrt_release_file" ] || { echo "Not an OpenWrt system ($owrt_release_file not present) Aborting." ; exit 1 ; }
+
+# Check first line of $owrt_release_file has "NAME=OpenWRT"
+is_openwrt=$(grep "$owrt_release_file" -e '^NAME=' | awk 'BEGIN { FS = "=" } { gsub(/"/, "", $2); print $2 }')
+if [ $is_openwrt != OpenWrt ] ; then { echo "Bad name for OpenWrt (NAME=$is_openwrt). Aborting." ; exit 1 ; } fi
+
+# It's an OpenWrt system - we can proceed with the installation
+echo ">>> Installing on OpenWrt..."
+echo ">>> Refreshing package cache. This may take a few moments..."
+opkg update -V0
+check_for_sqm
+
+# Install the required packages for sqm-autorate ...
+echo ">>> Installing required packages via opkg..."
+opkg install -V0 curl lua luarocks lua-bit32 luaposix lualanes && luarocks install vstruct
+
+# Try to install lua-argparse if possible...
+echo ">> Looking for lua-argparse..."
+if [ "$(opkg find lua-argparse | wc -l)" = "1" ]; then
+    echo ">>> Installing lua-argparse..."
+    opkg install -V0 lua-argparse
+else
+    echo "!! The lua-argparse package is not available for your distro. This means additional command-line options and arguments will not be available to you."
+fi
+
+# Now copy the important files to their destinations
 [ -d "./.git" ] && is_git_proj=true || is_git_proj=false
 
 if [ "$is_git_proj" = false ]; then
     # Need to curl some stuff down...
-    echo ">>> Pulling down sqm-autorate operational files..."
+    echo ">>> Retrieving sqm-autorate operational files..."
     curl -o "$config_file" "$repo_root/config/$config_file"
     curl -o "$service_file" "$repo_root/service/$service_file"
     curl -o "$lua_file" "$repo_root/lib/$lua_file"
@@ -83,103 +115,81 @@ else
     echo "> Since this is a Git project, local files will be used and will be COPIED into place instead of MOVED..."
 fi
 
-if [ -f "$owrt_release_file" ]; then
-    is_openwrt=$(grep "$owrt_release_file" -e '^NAME=' | awk 'BEGIN { FS = "=" } { gsub(/"/, "", $2); print $2 }')
-    if [ "$is_openwrt" = "OpenWrt" ]; then
-        echo ">> This is an OpenWrt system."
-        echo ">>> Refreshing package cache. This may take a few moments..."
-        opkg update -V0
-        check_for_sqm
-
-        # Install the sqm-autorate prereqs...
-        echo ">>> Installing prerequisite packages via opkg..."
-        opkg install -V0 lua luarocks lua-bit32 luaposix lualanes && luarocks install vstruct
-
-        # Try to install lua-argparse if possible...
-        echo ">> Checking to see if lua-argparse is available for install..."
-        if [ "$(opkg find lua-argparse | wc -l)" = "1" ]; then
-            echo ">>> It is available. Installing lua-argparse..."
-            opkg install -V0 lua-argparse
-        else
-            echo "!! The lua-argparse package is not available for your distro. This means additional command-line options and arguments will not be available to you."
-        fi
-
-        echo ">>> Putting config file into place..."
-        if [ -f "/etc/config/sqm-autorate" ]; then
-            echo "!!! Warning: An sqm-autorate config file already exists. This new config file will be created as $name-NEW. Please review and merge any updates into your existing $name file."
-            if [ "$is_git_proj" = true ]; then
-                cp "./config/$config_file" "/etc/config/$name-NEW"
-            else
-                mv "./$config_file" "/etc/config/$name-NEW"
-            fi
-        else
-            if [ "$is_git_proj" = true ]; then
-                cp "./config/$config_file" "/etc/config/$name"
-            else
-                mv "./$config_file" "/etc/config/$name"
-            fi
-        fi
-
-        # transition section 1 - to be removed
-        if grep -q -e 'receive' -e 'transmit' "/etc/config/$name" ; then
-            echo ">>> Revising config option names..."
-            uci rename sqm-autorate.@network[0].transmit_interface=upload_interface
-            uci rename sqm-autorate.@network[0].receive_interface=download_interface
-            uci rename sqm-autorate.@network[0].transmit_kbits_base=upload_base_kbits
-            uci rename sqm-autorate.@network[0].receive_kbits_base=download_base_kbits
-
-            t1=$( uci -q get sqm-autorate.@network[0].transmit_kbits_min )
-            uci delete sqm-autorate.@network[0].transmit_kbits_min
-            if [ -n "${t1}" ] && [ "${t1}" != "1500" ] ; then
-                t2=$( uci -q get sqm-autorate.@network[0].upload_base_kbits )
-                t1=$((t1 * 100 / t2))
-                if [ $t1 -lt 10 ] ; then
-                    t1=10
-                elif [ $t1 -gt 75 ] ; then
-                    t1=75
-                fi
-                uci set sqm-autorate.@network[0].upload_min_percent="${t1}"
-            fi
-
-            t1=$( uci -q get sqm-autorate.@network[0].receive_kbits_min )
-            uci delete sqm-autorate.@network[0].receive_kbits_min
-            if [ -n "${t1}" ] && [ "${t1}" != "1500" ] ; then
-                t2=$( uci -q get sqm-autorate.@network[0].download_base_kbits )
-                t1=$((t1 * 100 / t2))
-                if [ $t1 -lt 10 ] ; then
-                    t1=10
-                elif [ $t1 -gt 75 ] ; then
-                    t1=75
-                fi
-                uci set sqm-autorate.@network[0].download_min_percent="${t1}"
-            fi
-
-            uci -q add sqm-autorate advanced_settings 1> /dev/null
-
-            t=$( uci -q get sqm-autorate.@output[0].hist_size )
-            if [ -n "${t}" ] ; then
-                uci delete sqm-autorate.@output[0].hist_size
-                if [ "${t}" != "100" ] ; then
-                    uci set sqm-autorate.@advanced_settings[0].speed_hist_size="${t}"
-                fi
-            fi
-            t=$( uci -q get sqm-autorate.@network[0].reflector_type )
-            if [ -n "${t}" ] ; then
-                uci delete sqm-autorate.@network[0].reflector_type
-                if [ "${t}" != "icmp" ] ; then
-                    uci set sqm-autorate.@advanced_settings[0].reflector_type="${t}"
-                fi
-            fi
-
-            uci set sqm-autorate.@advanced_settings[0].upload_delay_ms=15
-            uci set sqm-autorate.@advanced_settings[0].download_delay_ms=15
-
-            uci commit
-        fi
+echo ">>> Putting config file into place..."
+if [ -f "/etc/config/sqm-autorate" ]; then
+    echo "!!! Warning: An sqm-autorate config file already exists. This new config file will be created as $name-NEW. Please review and merge any updates into your existing $name file."
+    if [ "$is_git_proj" = true ]; then
+        cp "./config/$config_file" "/etc/config/$name-NEW"
+    else
+        mv "./$config_file" "/etc/config/$name-NEW"
+    fi
+else
+    if [ "$is_git_proj" = true ]; then
+        cp "./config/$config_file" "/etc/config/$name"
+    else
+        mv "./$config_file" "/etc/config/$name"
     fi
 fi
 
-echo ">>> Putting sqm-autorate lib files into place..."
+# transition section 1 - to be removed
+# Remove/rename old format names "receive_xxx" and "transmit_xxx"
+if grep -q -e 'receive' -e 'transmit' "/etc/config/$name" ; then
+    echo ">>> Revising config option names..."
+    uci rename sqm-autorate.@network[0].transmit_interface=upload_interface
+    uci rename sqm-autorate.@network[0].receive_interface=download_interface
+    uci rename sqm-autorate.@network[0].transmit_kbits_base=upload_base_kbits
+    uci rename sqm-autorate.@network[0].receive_kbits_base=download_base_kbits
+
+    t1=$( uci -q get sqm-autorate.@network[0].transmit_kbits_min )
+    uci delete sqm-autorate.@network[0].transmit_kbits_min
+    if [ -n "${t1}" ] && [ "${t1}" != "1500" ] ; then
+        t2=$( uci -q get sqm-autorate.@network[0].upload_base_kbits )
+        t1=$((t1 * 100 / t2))
+        if [ $t1 -lt 10 ] ; then
+            t1=10
+        elif [ $t1 -gt 75 ] ; then
+            t1=75
+        fi
+        uci set sqm-autorate.@network[0].upload_min_percent="${t1}"
+    fi
+
+    t1=$( uci -q get sqm-autorate.@network[0].receive_kbits_min )
+    uci delete sqm-autorate.@network[0].receive_kbits_min
+    if [ -n "${t1}" ] && [ "${t1}" != "1500" ] ; then
+        t2=$( uci -q get sqm-autorate.@network[0].download_base_kbits )
+        t1=$((t1 * 100 / t2))
+        if [ $t1 -lt 10 ] ; then
+            t1=10
+        elif [ $t1 -gt 75 ] ; then
+            t1=75
+        fi
+        uci set sqm-autorate.@network[0].download_min_percent="${t1}"
+    fi
+
+    uci -q add sqm-autorate advanced_settings 1> /dev/null
+
+    t=$( uci -q get sqm-autorate.@output[0].hist_size )
+    if [ -n "${t}" ] ; then
+        uci delete sqm-autorate.@output[0].hist_size
+        if [ "${t}" != "100" ] ; then
+            uci set sqm-autorate.@advanced_settings[0].speed_hist_size="${t}"
+        fi
+    fi
+    t=$( uci -q get sqm-autorate.@network[0].reflector_type )
+    if [ -n "${t}" ] ; then
+        uci delete sqm-autorate.@network[0].reflector_type
+        if [ "${t}" != "icmp" ] ; then
+            uci set sqm-autorate.@advanced_settings[0].reflector_type="${t}"
+        fi
+    fi
+
+    uci set sqm-autorate.@advanced_settings[0].upload_delay_ms=15
+    uci set sqm-autorate.@advanced_settings[0].download_delay_ms=15
+
+    uci commit
+fi
+
+echo ">>> Copying sqm-autorate lib files into place..."
 mkdir -p "$autorate_lib_path"
 if [ "$is_git_proj" = true ]; then
     cp "./lib/$lua_file" "$autorate_lib_path/$lua_file"


### PR DESCRIPTION
1. Lua code (all logging) now honors the logging level. This minimizes ever-growing log files if log_level set to WARN or above

2. Setup Script: No intended change to functionality, edited to:
	- Factor out abort message at the start of the main routine;
	- Add 'curl' as a required package
	- Move curl/copy-from-git after massaging /etc/config/sqm-autorate;
	- Add/edit a few comments

3. retrievestats.sh script - run this on your laptop to retrieve the log files from a remote OpenWrt device for troubleshooting.