### PR TITLE
Ensure that packets sent to reflectors are sent from the correct wan interface

### DIFF
--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -397,6 +397,9 @@ local function send_icmp_pkt(reflector, pkt_id)
 
     logger(loglevel.TRACE, "Entered send_icmp_pkt() with values: " .. reflector .. " | " .. pkt_id)
 
+    -- Bind socket to the upload device prior to send
+    socket.setsockopt(sock, socket.SOL_SOCKET, socket.SO_BINDTODEVICE, ul_if)
+
     -- Create a raw ICMP timestamp request message
     local time_after_midnight_ms = get_time_after_midnight_ms()
     local ts_req = vstruct.write("> 2*u1 3*u2 3*u4", {13, 0, 0, pkt_id, 0, time_after_midnight_ms, 0, 0})
@@ -430,6 +433,9 @@ local function send_udp_pkt(reflector, pkt_id)
     -- Transmit timestamp (nanoseconds) - 4 bytes
 
     logger(loglevel.TRACE, "Entered send_udp_pkt() with values: " .. reflector .. " | " .. pkt_id)
+
+    -- Bind socket to the upload device prior to send
+    socket.setsockopt(sock, socket.SOL_SOCKET, socket.SO_BINDTODEVICE, ul_if)
 
     -- Create a raw ICMP timestamp request message
     local time, time_ns = get_current_time()


### PR DESCRIPTION
In multiwan setups (load balanced or failover) we need to ensure that the service sends packets from the correct device.
Currently if a primary interface is torn down the script sends packets over the failover interface which skews the tracking stats (particularly if the links have significantly differnet base RTTs).

I've amended the send_icmp_pkt and send_udp_pkt functions to ensure that the socket is bound to the correct device prior to sending a probe to a reflector.

This is done as part of the send function because the SO_BINDTODEVICE sockopt does not persist after a device is removed and added back into the system, and so it needs to be re-set.
Feasibly we could re-bind on an ad-hoc basis if we implement a mechanism to actively handle device states - but such a function might not be worth while from an efficiency perspective.