### PR TITLE
Avoid getting Linda on each loop run in baseline_calculator

### DIFF
--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -749,11 +749,12 @@ local function baseline_calculator()
     local slow_factor = ewma_factor(tick_duration, 135)
     local fast_factor = ewma_factor(tick_duration, 0.4)
 
+    local owd_tables = owd_data:get("owd_tables")
+    local owd_baseline = owd_tables["baseline"]
+    local owd_recent = owd_tables["recent"]
+
     while true do
         local _, time_data = stats_queue:receive(nil, "stats")
-        local owd_tables = owd_data:get("owd_tables")
-        local owd_baseline = owd_tables["baseline"]
-        local owd_recent = owd_tables["recent"]
 
         if time_data then
             if not owd_baseline[time_data.reflector] then


### PR DESCRIPTION
The owd_data Linda is not modified outside the baseline_calculator function,
as such there's no need to get it every time the loop runs.

On my device this halves the CPU usage of the baseliner thread