### PR TITLE
Replace luci.model.uci with uci from libuci-lua

### DIFF
--- a/lib/settings.lua
+++ b/lib/settings.lua
@@ -163,8 +163,8 @@ function M.initialise(requires, version, arg_reflector_data)
     -- Figure out if we are running on OpenWrt here and load luci.model.uci if available...
     local uci_lib
     local uci_settings
-    if util.is_module_available("luci.model.uci") then
-        uci_lib = require("luci.model.uci")
+    if util.is_module_available("uci") then
+        uci_lib = require("uci")
         uci_settings = uci_lib.cursor()
 
         M.plugin = function(plugin_name)

--- a/sqm-autorate-setup.sh
+++ b/sqm-autorate-setup.sh
@@ -120,7 +120,7 @@ fi
 
 # Install the required packages for sqm-autorate ...
 echo ">>> Installing required packages via opkg..."
-install="opkg install -V0 lua luarocks lua-bit32 luaposix lualanes luci-mod-rpc tar ${lua_argparse} ${curl}"
+install="opkg install -V0 libuci-lua lua luarocks lua-bit32 luaposix lualanes tar ${lua_argparse} ${curl}"
 $install
 
 echo ">>> Installing required packages via luarocks..."


### PR DESCRIPTION
libuci-lua is a tiny wrapper around the uci library for Lua and for our purposes seems to be a drop-in replacement.
avoids requiring luci when it's not really needed