### PR TITLE
Adjust minimum rate percentages

### DIFF
--- a/lib/settings.lua
+++ b/lib/settings.lua
@@ -259,7 +259,7 @@ function M.initialise(requires, version, arg_reflector_data)
         if upload_min_percent == nil then
             M.min_ul_rate = floor(M.base_ul_rate / 5) -- 20%
         else
-            upload_min_percent = limit(tonumber(upload_min_percent), 10, 75)
+            upload_min_percent = limit(tonumber(upload_min_percent), 1, 80)
             M.min_ul_rate = floor(M.base_ul_rate * upload_min_percent / 100)
         end
     end
@@ -272,7 +272,7 @@ function M.initialise(requires, version, arg_reflector_data)
         if download_min_percent == nil then
             M.min_dl_rate = floor(M.base_dl_rate / 5) -- 20%
         else
-            download_min_percent = limit(tonumber(download_min_percent), 10, 75)
+            download_min_percent = limit(tonumber(download_min_percent), 1, 80)
             M.min_dl_rate = floor(M.base_dl_rate * download_min_percent / 100)
         end
     end


### PR DESCRIPTION
Set the lower bound of the minimum rate to 1% and the upper bound to 80%. Closes #192 